### PR TITLE
Set equipmentTypes configuration

### DIFF
--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -147,6 +147,18 @@ function applyElevationToSelected(token, data, options, id) {
 /* -------------------------------------------- */
 
 /**
+ * Set CONFIG.DND5E.equipmentTypes using CONFIG.DND5E.miscEquipmentTypes and CONFIG.DND5E.armorTypes
+ */
+export function setEquipmentTypes(maxLevel = null) {
+  CONFIG.DND5E.equipmentTypes = {
+    ...CONFIG.DND5E.miscEquipmentTypes,
+    ...CONFIG.DND5E.armorTypes
+  };
+}
+
+/* -------------------------------------------- */
+
+/**
  * Set CONFIG.DND5E.maxAbilityScore.
  * @param {number|null} maxAbilityScore The max ability score
  */

--- a/scripts/misc.js
+++ b/scripts/misc.js
@@ -149,7 +149,7 @@ function applyElevationToSelected(token, data, options, id) {
 /**
  * Set CONFIG.DND5E.equipmentTypes using CONFIG.DND5E.miscEquipmentTypes and CONFIG.DND5E.armorTypes
  */
-export function setEquipmentTypes(maxLevel = null) {
+export function setEquipmentTypes() {
   CONFIG.DND5E.equipmentTypes = {
     ...CONFIG.DND5E.miscEquipmentTypes,
     ...CONFIG.DND5E.armorTypes

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -23,7 +23,7 @@ import { register as registerItemSheet } from "./item-sheet.js";
 import { register as registerMigration, migrate, migrations } from "./migration.js";
 import { register as registerInterface } from "./interface.js";
 import { register as registerItemInteractions } from "./item-interactions.js";
-import { register as registerMisc, setMaxLevel } from "./misc.js";
+import { register as registerMisc, setEquipmentTypes, setMaxLevel } from "./misc.js";
 import { register as registerRolls } from "./rolls.js";
 import { register as registerRadialStatusEffects } from "./token/radial-status-effects.js";
 import { register as registerRulerTravelTime } from "./interface/ruler-travel-time.js";
@@ -264,5 +264,6 @@ Hooks.on("ready", async () => {
   configs.weaponIds.setConfig();
   configs.weaponMasteries.setConfig();
   configs.weaponProficiencies.setConfig();
+  setEquipmentTypes()
   setMaxLevel(getSetting(CONSTANTS.MAX_LEVEL.SETTING.KEY));
 });

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -264,6 +264,6 @@ Hooks.on("ready", async () => {
   configs.weaponIds.setConfig();
   configs.weaponMasteries.setConfig();
   configs.weaponProficiencies.setConfig();
-  setEquipmentTypes()
+  setEquipmentTypes();
   setMaxLevel(getSetting(CONSTANTS.MAX_LEVEL.SETTING.KEY));
 });


### PR DESCRIPTION
CONFIG.DND5E.equipmentTypes is set by the D&D 5E system as a combination of the armorTypes and miscEquipmentTypes configs. It is referenced by the data definition for equipment-type items at [module/data/item/equipment.mjs](https://github.com/foundryvtt/dnd5e/blob/12d64a3509310f90f46e2a7e00d934e28fc7610c/module/data/item/equipment.mjs#L168), but it isn't modified by the Custom D&D 5E module. When equipment types are renamed or added via Custom D&D 5E, this can lead to some visual discrepancies between the Equipment Type dropdown menu and the equipment type displayed on the item sheet.

<img width="1018" height="920" alt="Screenshot 2026-06-28 121530" src="https://github.com/user-attachments/assets/cc615c47-ff35-4140-ac40-ec48e5379c14" />

This PR adds a setEquipmentTypes function to scripts/misc.js, which is called near the end of scripts/module.js, syncing the equipmentTypes config to the armorTypes and miscEquipmentTypes set by the module.

<img width="1012" height="912" alt="Screenshot 2026-06-28 123112" src="https://github.com/user-attachments/assets/28977983-586c-4a50-9108-7b620440355b" />